### PR TITLE
Org password reset

### DIFF
--- a/client/src/components_orgpage/OrgLogin.js
+++ b/client/src/components_orgpage/OrgLogin.js
@@ -151,12 +151,24 @@ export default function OrgLogin(props) {
           hideModal={() => setShowModal(false)}
         />
       );
-    } else if (modalType === "forgot") {
+    } else if (modalType === "forgot admin") {
       modal = (
         <ResetPassword
           showModal={showModal}
           hideModal={() => setShowModal(false)}
           handleSubmitForgot={handleAdminSubmitForgot}
+          fields={fields}
+          show_toast={show_toast}
+          setShowToast={setShowToast}
+          handleFieldChange={handleFieldChange}
+        />
+      );
+    } else if (modalType === "forgot org") {
+      modal = (
+        <ResetPassword
+          showModal={showModal}
+          hideModal={() => setShowModal(false)}
+          handleSubmitForgot={handleSubmitForgot}
           fields={fields}
           show_toast={show_toast}
           setShowToast={setShowToast}
@@ -235,7 +247,7 @@ export default function OrgLogin(props) {
                 <Button
                   variant="link"
                   id="regular-text"
-                  onClick={() => handleShowModal("forgot")}
+                  onClick={() => handleShowModal("forgot admin")}
                   style={{
                     color: "#2670FF",
                     padding: 0,
@@ -245,6 +257,22 @@ export default function OrgLogin(props) {
                   }}
                 >
                   Forgot your admin password?
+                </Button>
+              </Row>
+              <Row>
+                <Button
+                  variant="link"
+                  id="regular-text"
+                  onClick={() => handleShowModal("forgot org")}
+                  style={{
+                    color: "#2670FF",
+                    padding: 0,
+                    textDecoration: "underline",
+                    marginTop: -2,
+                    marginLeft: 14,
+                  }}
+                >
+                  Forgot your organization password?
                 </Button>
               </Row>
               {/* <p id="regular-text" style={{ marginTop: 5, color: "#2670FF", fontSize: 16 }}> 

--- a/client/src/components_orgpage/OrgLogin.js
+++ b/client/src/components_orgpage/OrgLogin.js
@@ -260,7 +260,7 @@ export default function OrgLogin(props) {
                 </Button>
               </Row>
               <Row>
-                <Button
+                {/* <Button
                   variant="link"
                   id="regular-text"
                   onClick={() => handleShowModal("forgot org")}
@@ -273,7 +273,7 @@ export default function OrgLogin(props) {
                   }}
                 >
                   Forgot your organization password?
-                </Button>
+                </Button> */}
               </Row>
               {/* <p id="regular-text" style={{ marginTop: 5, color: "#2670FF", fontSize: 16 }}> 
                 For organization password resets, please contact Covaid tech support

--- a/controllers/association.controller.js
+++ b/controllers/association.controller.js
@@ -194,19 +194,14 @@ exports.verifyPasswordResetLink = asyncWrapper(async (req, res) => {
 });
 
 exports.resetPassword = asyncWrapper(async (req, res) => {
-  console.log("WTFFFF")
   var newPassword = req.body.newPassword;
   // update password
   const association = await Association.findById(req.body.id);
-  console.log("found it")
   association.setPassword(newPassword);
-  console.log("set Password")
   association.save(function (err, result) {
     if (err) {
-      console.log("error")
       return res.status(422).send(err);
     }
-    console.log("WROKSSS")
     res.sendStatus(200);
   });
 });

--- a/controllers/association.controller.js
+++ b/controllers/association.controller.js
@@ -194,14 +194,19 @@ exports.verifyPasswordResetLink = asyncWrapper(async (req, res) => {
 });
 
 exports.resetPassword = asyncWrapper(async (req, res) => {
+  console.log("WTFFFF")
   var newPassword = req.body.newPassword;
   // update password
   const association = await Association.findById(req.body.id);
+  console.log("found it")
   association.setPassword(newPassword);
+  console.log("set Password")
   association.save(function (err, result) {
     if (err) {
+      console.log("error")
       return res.status(422).send(err);
     }
+    console.log("WROKSSS")
     res.sendStatus(200);
   });
 });

--- a/util/emailer.js
+++ b/util/emailer.js
@@ -192,7 +192,7 @@ exports.sendAssocPasswordLink = (email, assocID, token) => {
     },
   };
   //send the email
-  // if (process.env.PROD) {
+  if (process.env.PROD) {
     sgMail.send(msg, (error, result) => {
       if (error) {
         console.log(error);
@@ -200,7 +200,7 @@ exports.sendAssocPasswordLink = (email, assocID, token) => {
         console.log("Email sent!");
       }
     });
-  // }
+  }
 };
 
 exports.sendAssocAdminPasswordLink = (email, assocID, token) => {

--- a/util/emailer.js
+++ b/util/emailer.js
@@ -165,7 +165,7 @@ exports.sendBeaconEmail = (data) => {
 };
 
 exports.sendAssocPasswordLink = (email, assocID, token) => {
-  var test = "localhost:3000";
+  var test = "covaid.co";
   var production = "covaid.co";
   var page = production;
   if (process.env.PORT) {

--- a/util/emailer.js
+++ b/util/emailer.js
@@ -192,7 +192,7 @@ exports.sendAssocPasswordLink = (email, assocID, token) => {
     },
   };
   //send the email
-  if (process.env.PROD) {
+  // if (process.env.PROD) {
     sgMail.send(msg, (error, result) => {
       if (error) {
         console.log(error);
@@ -200,7 +200,7 @@ exports.sendAssocPasswordLink = (email, assocID, token) => {
         console.log("Email sent!");
       }
     });
-  }
+  // }
 };
 
 exports.sendAssocAdminPasswordLink = (email, assocID, token) => {

--- a/util/emailer.js
+++ b/util/emailer.js
@@ -165,16 +165,6 @@ exports.sendBeaconEmail = (data) => {
 };
 
 exports.sendAssocPasswordLink = (email, assocID, token) => {
-  var nodemailer = require("nodemailer");
-
-  var transporter = nodemailer.createTransport({
-    service: "gmail",
-    auth: {
-      user: "covaidco@gmail.com",
-      pass: "covaid_platform_2020!",
-    },
-  });
-
   var test = "localhost:3000";
   var production = "covaid.co";
   var page = production;
@@ -184,7 +174,6 @@ exports.sendAssocPasswordLink = (email, assocID, token) => {
     page = test;
   }
   var body =
-    "Click here to reset your password: " +
     "http://" +
     page +
     "/resetAssociationPassword?ID=" +
@@ -192,20 +181,26 @@ exports.sendAssocPasswordLink = (email, assocID, token) => {
     "&Token=" +
     token;
 
-  var mailOptions = {
-    from: "covaidco@gmail.com",
+  const msg = {
+    //extract the email details
     to: email,
-    subject: "Covaid -- Reset your password",
-    text: body,
+    from: "Covaid@covaid.co",
+    templateId: templates["reset_password"],
+    //extract the custom fields
+    dynamic_template_data: {
+      link: body,
+    },
   };
-
-  transporter.sendMail(mailOptions, function (error, info) {
-    if (error) {
-      console.log(error);
-    } else {
-      console.log("Email sent: " + info.response);
-    }
-  });
+  //send the email
+  if (process.env.PROD) {
+    sgMail.send(msg, (error, result) => {
+      if (error) {
+        console.log(error);
+      } else {
+        console.log("Email sent!");
+      }
+    });
+  }
 };
 
 exports.sendAssocAdminPasswordLink = (email, assocID, token) => {


### PR DESCRIPTION
Since password reset only works if an org has a phone number and not all of them do. We'll merge in the backend for org password reset but the frontend will be commented out. If an org needs to reset their password like Athens. We can use the frontend on localhost to send a link to their email. 